### PR TITLE
enable download counter for HACS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,28 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  release_zip_file:
+    name: Prepare release asset
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      # Pack the resol dir as a zip and upload to the release
+      - name: ZIP resol Dir
+        run: |
+          cd ${{ github.workspace }}/custom_components/resol
+          zip resol.zip -r ./
+      - name: Upload zip to release
+        uses: svenstaro/upload-release-action@v1-release
+
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: ${{ github.workspace }}/custom_components/resol/resol.zip
+          asset_name: resol.zip
+          tag: ${{ github.ref }}
+          overwrite: true

--- a/hacs.json
+++ b/hacs.json
@@ -1,5 +1,7 @@
 {
   "name": "Resol Controller (UI Based) for KM1/KM2, DL2, JSON Live Data Server",
   "homeassistant": "2024.8",
-  "render_readme": true
+  "render_readme": true,
+  "zip_release": true,
+  "filename": "resol.zip"
 }


### PR DESCRIPTION
@evercape you need to add the GITHUB_TOKEN to your repo to make it work, then after you are releasing a new version a zip is built on release and hacs uses the zip to install it on users side. these downloads are counted on github, so with this information the download counter on HACS is showing the amount of downloads